### PR TITLE
Add Streamlit CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # WebLEDMatrix
 
-```shell
+A small Streamlit application for controlling LED matrix controllers.
+
+## Installation
+
+The package can be installed from source using Poetry or pip:
+
+```bash
 poetry install
 poetry build
 pip install dist/
+```
+
+## Usage
+
+After installation a command line entry point named `web-led-matrix` is available.
+It launches the Streamlit interface for selecting and identifying matrices:
+
+```bash
+web-led-matrix
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "streamlit (>=1.46.0,<2.0.0)"
 ]
 
+[project.scripts]
+web-led-matrix = "web_led_matrix.cli:main"
+
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/web_led_matrix/__init__.py
+++ b/web_led_matrix/__init__.py
@@ -1,75 +1,11 @@
-from threading import Thread
-import streamlit as st
-from is_matrix_forge.led_matrix.controller.helpers import get_controllers
-import time
+from .app import MatrixControllerApp
 
+__all__ = ["MatrixControllerApp", "run"]
 
-class MatrixControllerApp:
-    """
-    A Streamlit app to select LED matrices and run an identify routine on them.
-    Supports concurrent identification with visual feedback.
-    """
-
-    def __init__(self):
-        self.controllers = get_controllers()
-        self.controller_names = [c.name for c in self.controllers]
-
-        if 'processing' not in st.session_state:
-            st.session_state.processing = False
-        if 'identify_threads' not in st.session_state:
-            st.session_state.identify_threads = []
-
-    def _identify_controller(self, controller):
-        controller.identify()
-
-    def handle_identify(self):
-        selected = st.session_state.select_matrix
-        threads = []
-
-        if selected == 'All':
-            for ctrl in self.controllers:
-                t = Thread(target=self._identify_controller, args=(ctrl,), daemon=True)
-                threads.append(t)
-        else:
-            idx = self.controller_names.index(selected)
-            t = Thread(target=self._identify_controller, args=(self.controllers[idx],), daemon=True)
-            threads.append(t)
-
-        st.session_state.identify_threads = threads
-        st.session_state.processing = True
-
-        for thread in threads:
-            thread.start()
-
-        st.rerun()
-
-    def run(self):
-        threads = st.session_state.identify_threads
-        if threads:
-            if all(not t.is_alive() for t in threads):
-                st.session_state.processing = False
-                st.session_state.identify_threads = []
-
-        st.title("LED Matrix Control")
-
-        disabled = st.session_state.processing or bool(st.session_state.identify_threads)
-
-        selected_matrix = st.selectbox(
-            "Select a matrix",
-            options=self.controller_names + ["All"],
-            key="select_matrix",
-            disabled=disabled,
-        )
-
-        if st.button("Identify", disabled=disabled):
-            self.handle_identify()
-
-        if disabled:
-            with st.spinner("Identifying..."):
-                while any(t.is_alive() for t in st.session_state.identify_threads):
-                    time.sleep(0.1)
-                st.rerun()
+def run() -> None:
+    """Launch the Streamlit application."""
+    MatrixControllerApp().run()
 
 
 if __name__ == "__main__":
-    MatrixControllerApp().run()
+    run()

--- a/web_led_matrix/app.py
+++ b/web_led_matrix/app.py
@@ -1,0 +1,75 @@
+from threading import Thread
+import streamlit as st
+from is_matrix_forge.led_matrix.controller.helpers import get_controllers
+import time
+
+
+class MatrixControllerApp:
+    """
+    A Streamlit app to select LED matrices and run an identify routine on them.
+    Supports concurrent identification with visual feedback.
+    """
+
+    def __init__(self):
+        self.controllers = get_controllers()
+        self.controller_names = [c.name for c in self.controllers]
+
+        if 'processing' not in st.session_state:
+            st.session_state.processing = False
+        if 'identify_threads' not in st.session_state:
+            st.session_state.identify_threads = []
+
+    def _identify_controller(self, controller):
+        controller.identify()
+
+    def handle_identify(self):
+        selected = st.session_state.select_matrix
+        threads = []
+
+        if selected == 'All':
+            for ctrl in self.controllers:
+                t = Thread(target=self._identify_controller, args=(ctrl,), daemon=True)
+                threads.append(t)
+        else:
+            idx = self.controller_names.index(selected)
+            t = Thread(target=self._identify_controller, args=(self.controllers[idx],), daemon=True)
+            threads.append(t)
+
+        st.session_state.identify_threads = threads
+        st.session_state.processing = True
+
+        for thread in threads:
+            thread.start()
+
+        st.rerun()
+
+    def run(self):
+        threads = st.session_state.identify_threads
+        if threads:
+            if all(not t.is_alive() for t in threads):
+                st.session_state.processing = False
+                st.session_state.identify_threads = []
+
+        st.title("LED Matrix Control")
+
+        disabled = st.session_state.processing or bool(st.session_state.identify_threads)
+
+        selected_matrix = st.selectbox(
+            "Select a matrix",
+            options=self.controller_names + ["All"],
+            key="select_matrix",
+            disabled=disabled,
+        )
+
+        if st.button("Identify", disabled=disabled):
+            self.handle_identify()
+
+        if disabled:
+            with st.spinner("Identifying..."):
+                while any(t.is_alive() for t in st.session_state.identify_threads):
+                    time.sleep(0.1)
+                st.rerun()
+
+
+if __name__ == "__main__":
+    MatrixControllerApp().run()

--- a/web_led_matrix/cli.py
+++ b/web_led_matrix/cli.py
@@ -1,0 +1,16 @@
+"""Command-line interface for the Web LED Matrix app."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    """Launch the Streamlit application."""
+    package_dir = Path(__file__).resolve().parent
+    app_path = package_dir / "__init__.py"
+    return subprocess.call(["streamlit", "run", str(app_path)])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- restructure package and move app class to `app.py`
- add `cli.py` that calls `streamlit run` on `__init__.py`
- expose `web-led-matrix` script in `pyproject.toml`
- document how to use the new entry point

## Testing
- `python -m pip install -e .` *(fails: Could not fetch poetry-core)*
- `python web_led_matrix/cli.py` *(starts streamlit server until interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685c74dacc08832d8ca39d1faa312610

## Summary by Sourcery

Provide a dedicated CLI entry point for the Streamlit LED matrix control app, reorganize the package layout for clearer separation of concerns, and update project configuration and documentation accordingly.

New Features:
- Introduce a `web-led-matrix` console script to launch the Streamlit app via CLI

Enhancements:
- Refactor package structure by moving `MatrixControllerApp` into `app.py` and streamlining `__init__.py` to expose the app and a `run` function
- Add a `cli.py` module that invokes `streamlit run` on the package entry point

Build:
- Register the `web-led-matrix` script in `pyproject.toml` under `project.scripts`

Documentation:
- Update README with installation steps and usage instructions for the new CLI entry point